### PR TITLE
feat: integrate event details data

### DIFF
--- a/src/app/events/[eventId]/page.jsx
+++ b/src/app/events/[eventId]/page.jsx
@@ -18,6 +18,30 @@ function page({ params }) {
   //   high: BigInt(0),
   // };
 
+  useEffect(() => {
+    async function fetchEventDetails() {
+      try {
+        let request = await fetch(
+          "https://chainevents-backend.onrender.com/event/id/1"
+        );
+        if (!request.ok) {
+          throw new Error("Failed to fetch data");
+        }
+        let response = await request.json();
+        if (data?.length === 0) {
+          console.log("No data");
+          setEventData([]);
+          return;
+        }
+        console.log(response.data);
+        setEventData(response.data);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    fetchEventDetails();
+  }, []);
+
   const { data, isLoading, error, isFetching } = useContractFetch(
     contractAbi,
     "event_details",
@@ -44,7 +68,7 @@ function page({ params }) {
     if (data) {
       const processed = processEventData(data);
       console.log("Processed event data:", processed);
-      setEventData(processed);
+      //setEventData(processed);
     }
   }, [data]);
 
@@ -72,34 +96,41 @@ function page({ params }) {
       <main className="pt-[74px] pb-[197px]">
         <div className="w-[740px] mx-auto bg-[#1E1D1D] rounded border-[.3px] border-[#FFFFFF] p-4 grid grid-cols-[250px_1fr] gap-x-6">
           <div>
-            <img src="/assets/eventImage.png" className="w-full mb-4" alt="" />
+            <img
+              src={`${eventData?.["event_image_url"] ?? "/assets/eventImage.png"}`}
+              className="w-full mb-4"
+              alt=""
+            />
             <h3 className="pb-2 border-b-[.4px] border-b-[#C4C4CC44] mb-2">
               Hosted By
             </h3>
             <div className="flex flex-col gap-y-2 text-xs leading-4 font-medium py-2 mb-6">
               <div className="flex gap-x-2 items-center">
                 <img src="/assets/host-avatar.svg" className="w-5 h-5" alt="" />
-                <h3>June Kankanda</h3>
+                <h3>{eventData?.["event_owner"]}</h3>
               </div>
               <div className="flex gap-x-2 items-center">
                 <img src="/assets/host-avatar.svg" className="w-5 h-5" alt="" />
-                <h3>Daniel John</h3>
+                <h3>{eventData?.["event_email"]}</h3>
               </div>
             </div>
 
             <h3 className="text-[#D9D9D9] text-xs leading-4">Contact Host</h3>
+            <h3 className="text-[#D9D9D9] text-xs leading-4">
+              {eventData?.["event_email"]}
+            </h3>
             <h3 className="text-[#D9D9D9] mt-3 text-xs leading-4">
               Report Event
             </h3>
           </div>
           <div>
             <h2 className="text-xl leading-6 font-semibold mb-4">
-              Workshop: Leveraging The Graph to build Your Dapp
+              {eventData?.name}
             </h2>
             <div className="flex items-center">
               <img src="/" alt="" />
               <div>
-                <h3 className="font-medium text-sm">Colab Innovation Campus</h3>
+                <h3 className="font-medium text-sm">{eventData?.location}</h3>
                 <h4 className="text-[#D9D9D9] text-xs">
                   No, 1 Technology City Boulevard/Crocodile road
                 </h4>
@@ -110,7 +141,10 @@ function page({ params }) {
               <div>
                 <h3 className="font-medium text-sm">Friday, Sep 6</h3>
                 <h4 className="text-[#D9D9D9] text-xs">
-                  10:00 AM - 12:00 PM GMT +1
+                  {eventData?.["event_start_date"] ?? "10:00 AM"} -{" "}
+                  {eventData?.["event_end_date"] ??
+                    `12:00 PM GMT
+                  +1`}
                 </h4>
               </div>
             </div>
@@ -131,15 +165,18 @@ function page({ params }) {
                 Welcome to join the Event, Please register below
               </p>
 
-              <button className="py-2 text-sm font-semibold rounded-full text-[#3A3A3A] bg-[#D9D9D9] w-full">
-                Request to Join
-              </button>
+              {eventData?.["open_for_registration"] && (
+                <button className="py-2 text-sm font-semibold rounded-full text-[#3A3A3A] bg-[#D9D9D9] w-full">
+                  Request to Join
+                </button>
+              )}
             </div>
             <h2 className="pb-2 text-xs border-b-[#C4C4CC44] border-b-[.4px] font-semibold text-white mb-4 mt-4">
               About Event
             </h2>
             <p className="text-xs leading-5">
-              Get hyped for the ultimate mixer at Devcon 🎉, brought to you by
+              {eventData?.description ??
+                ` Get hyped for the ultimate mixer at Devcon 🎉, brought to you by
               StarkWare & Pantera Capital & Braavos🚀 Vibe out with fellow
               crypto people 🪙 at a party where the drinks flow 🍹, the food is
               on point 🍣, and connections spark 🔥 We&apos;re turning the Stark
@@ -147,12 +184,12 @@ function page({ params }) {
               8 p.m., mingle with developers 👨‍💻👩‍💻 and other blockchain pioneers
               🛠️, and soak in the energy ⚡ Spots are limited, so it&apos;s
               first come, first served—make sure to get there early to secure
-              your place! ✨✨✨
+              your place! ✨✨✨`}
             </p>
             <h2 className="pb-2 text-xs border-b-[#C4C4CC44] border-b-[.4px] font-semibold text-white mb-4 mt-4">
               Location
             </h2>
-            <h3 className="text-sm font-semibold">Colab Innovation Campus</h3>
+            <h3 className="text-sm font-semibold">{eventData?.location}</h3>
             <h4 className="text-xs text-[#D9D9D9]">
               No, 1 Technology City Boulevard/Crocodile road
             </h4>

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -1,3 +1,4 @@
+"use client"
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 


### PR DESCRIPTION
- Integrate event detail data directly into the `http://localhost:3000/events/[page]` route using the provided endpoint
- Added a placeholder for fetched  data properties where their value is currently null
- Fix fail build
close: #54
![Screenshot_20250227_121615](https://github.com/user-attachments/assets/f193add5-b8d5-47a9-a502-ede482942d54)

